### PR TITLE
specify primary key and added OTP discard time

### DIFF
--- a/src/LoginMiddleware.php
+++ b/src/LoginMiddleware.php
@@ -54,7 +54,7 @@ class LoginMiddleware
             // define the flag for refreshing the OTP verification code
             $needsRefresh = false;
             // a record exists for the user in the database 
-            if ($otp instanceof OneTimePassword && $otp->status) {
+            if ($otp instanceof OneTimePassword) {
                 if ($this->debug) logger("otp found");
 
                 // if has a pending OTP verification request

--- a/src/LoginMiddleware.php
+++ b/src/LoginMiddleware.php
@@ -53,15 +53,8 @@ class LoginMiddleware
 
             // define the flag for refreshing the OTP verification code
             $needsRefresh = false;
-            // check if OTP is too old
-            if ($otp instanceof OneTimePassword) {
-                if ($otp->isDiscarded()) {
-                    if ($this->debug) logger("otp found but was old So is discarded, will request for a new");
-                    $otp->update(["status" => "discarded",]);
-                }
-            }
             // a record exists for the user in the database 
-            if ($otp instanceof OneTimePassword && $otp->status != "discarded") {
+            if ($otp instanceof OneTimePassword && $otp->status) {
                 if ($this->debug) logger("otp found");
 
                 // if has a pending OTP verification request

--- a/src/OneTimePassword.php
+++ b/src/OneTimePassword.php
@@ -121,9 +121,4 @@ class OneTimePassword extends Model
     {
         return $this->created_at < Carbon::now()->subSeconds(config("otp.otp_timeout"));
     }
-    // check if new OTP needs to send and verify
-    public function isDiscarded()
-    {
-        return $this->updated_at < Carbon::now()->subSeconds(config("otp.otp_discard_time"));
-    } 
 }

--- a/src/OneTimePassword.php
+++ b/src/OneTimePassword.php
@@ -18,7 +18,7 @@ class OneTimePassword extends Model
 
     public function user()
     {
-        return $this->hasOne(User::class, "id", "user_id");
+        return $this->hasOne(User::class, config("otp.user_id_field"), "user_id");
     }
 
     public function send()
@@ -64,7 +64,7 @@ class OneTimePassword extends Model
         $this->update(["status" => "waiting"]);
 
         $this->oneTimePasswordLogs()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $this->user->getAttribute(config("otp.user_id_field")),
             'otp_code' => $otp_code,
             'refer_number' => $ref,
             'status' => 'waiting',
@@ -113,12 +113,17 @@ class OneTimePassword extends Model
     {
         $this->update(["status" => "verified"]);
         $this->oneTimePasswordLogs()->where("status", "discarded")->delete();
-        OneTimePassword::where(["status" => "discarded", "user_id" => $this->user->id])->delete();
-        return $this->oneTimePasswordLogs()->where("user_id", $this->user->id)->where("status", "waiting")->update(["status" => "verified"]);
+        OneTimePassword::where(["status" => "discarded", "user_id" => $this->user->getAttribute(config("otp.user_id_field"))])->delete();
+        return $this->oneTimePasswordLogs()->where("user_id", $this->user->getAttribute(config("otp.user_id_field")))->where("status", "waiting")->update(["status" => "verified"]);
     }
 
     public function isExpired()
     {
         return $this->created_at < Carbon::now()->subSeconds(config("otp.otp_timeout"));
     }
+    // check if new OTP needs to send and verify
+    public function isDiscarded()
+    {
+        return $this->updated_at < Carbon::now()->subSeconds(config("otp.otp_discard_time"));
+    } 
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -23,10 +23,9 @@ return [
         ]
     ],
     'user_phone_field' => 'phone',
-    'user_id_field' => '_id',
+    'user_id_field' => 'id',
     'otp_reference_number_length' => 6,
     'otp_timeout' => 7890000,
     'otp_digit_length' => 6,
     'encode_password' => false,
-    'otp_discard_time'=>7890000
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -23,8 +23,10 @@ return [
         ]
     ],
     'user_phone_field' => 'phone',
+    'user_id_field' => '_id',
     'otp_reference_number_length' => 6,
     'otp_timeout' => 7890000,
     'otp_digit_length' => 6,
-    'encode_password' => false
+    'encode_password' => false,
+    'otp_discard_time'=>7890000
 ];


### PR DESCRIPTION
This pull request adds two new features to the tpak package. The first feature allows users to define their own custom primary key for the user table in the package's configuration file. This provides flexibility for users who have a non-standard database setup.

The second feature adds the ability to define the time period after which an OTP (one-time password) will be discarded in the configuration file. This allows users to set the expiration time for OTPs, after which they will be invalidated and a new OTP will need to be generated and have to be verified.

Both of these features are useful additions to the package and should improve its functionality and usability for users.